### PR TITLE
fix(hyprland): mitigate NVIDIA-related compositor freeze on launch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,10 @@
     };
 
     # Hyprland
-    hyprland.url = "https://flakehub.com/f/hyprwm/Hyprland/0.54.*";
+    hyprland = {
+      url = "https://flakehub.com/f/hyprwm/Hyprland/0.54.*";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     input-branches.url = "github:mightyiam/input-branches";
     clipboard-sync = {
       url = "github:dnut/clipboard-sync";

--- a/modules/nvidia-gpu.nix
+++ b/modules/nvidia-gpu.nix
@@ -21,7 +21,7 @@ in
         powerManagement.enable = true;
         powerManagement.finegrained = false;
         nvidiaSettings = true;
-        package = config.boot.kernelPackages.nvidiaPackages.beta;
+        package = config.boot.kernelPackages.nvidiaPackages.production;
       };
       nix.settings = {
         extra-substituters = [ "https://cuda-maintainers.cachix.org" ];

--- a/modules/wm/hyprland/hyprland.nix
+++ b/modules/wm/hyprland/hyprland.nix
@@ -149,6 +149,8 @@
 
           render = {
             direct_scanout = 0;
+            explicit_sync = 0;
+            explicit_sync_kms = 0;
           };
 
           master = {


### PR DESCRIPTION
## Summary

- Make the `hyprland` flake input follow top-level `nixpkgs` so the system no longer runs a split graphics stack (mesa from hyprland's older nixpkgs vs. kernel/nvidia from a newer nixpkgs).
- Move nvidia driver pin from `nvidiaPackages.beta` (595.45.04, Feb 2026 prerelease) to `nvidiaPackages.production` (595.71.05, current stable; includes the Linux 6.19 kernel build fix introduced in 595.58.03).
- Disable Hyprland `render.explicit_sync` / `render.explicit_sync_kms` — documented workaround for the NVIDIA Wayland freeze pattern (hyprwm/Hyprland#7230).

Triages a hard freeze observed when launching Hyprland on `linuxPackages_latest` (6.19 / 7.0.1) with the previous `nvidiaPackages.beta` pin.

`flake.lock` will refresh on the next `nh os boot` since nix wasn't available in the environment that produced this commit.

## Test plan

- [ ] `nh os boot --update` (or `nix flake update hyprland nixpkgs && nh os boot`) succeeds
- [ ] Boot, log in via tuigreet, launch Hyprland — no freeze
- [ ] Confirm the running driver: `cat /proc/driver/nvidia/version` reports 595.71.05
- [ ] Confirm explicit sync is off: `hyprctl getoption render:explicit_sync` shows 0
- [ ] No regression in screenshot/recording, screensharing, or OpenGL apps

https://claude.ai/code/session_012tkcv1VT3Zh9xocF5n4YKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012tkcv1VT3Zh9xocF5n4YKJ)_